### PR TITLE
Docker updates to get local dev env running

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,6 +5,7 @@ services:
     container_name: asai-app
     environment:
       - ENVIRONMENT=LOCAL DEV
+      - CGO_CFLAGS=-D_LARGEFILE64_SOURCE
     build:
       context: .
       dockerfile: ./env/docker/Dockerfile

--- a/env/docker/Dockerfile
+++ b/env/docker/Dockerfile
@@ -1,5 +1,5 @@
 # Use newer version of Golang and Alpine Linux as base image
-FROM golang:1.20-alpine3.18 AS builder
+FROM golang:1.22-alpine AS builder
 
 # Update packages and install needed dependencies
 RUN apk update && \


### PR DESCRIPTION
Update docker Go version to 1.22 to be compatible with Air
Add a flag to prevent sqlite driver from crashing 