### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ yarn install
 Vue needs to access the adminkit, for that we have to build it as a package. 
 
 ```bash
-cd web/arc/adminkit
+cd web/src/adminkit
 yarn install
 yarn build
 ```

--- a/README.md
+++ b/README.md
@@ -59,16 +59,6 @@ cd web
 yarn install
 ```
 
-#### Admin kit
-
-Vue needs to access the adminkit, for that we have to build it as a package. 
-
-```bash
-cd web/src/adminkit
-yarn install
-yarn build
-```
-
 Web client has CORS allowed to run alongised with the dockerised server. Run `yarn run dev` to run the web clinet on port 5173 as usaul. If you need the front end to be serverd at the same port as the dockerised app service, you can run `yarn run docker` to build the front ned for runing in docker, now the frontend is avaliable on port 8082.
 
 ### API keys

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/gorilla/handlers v1.5.2
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/websocket v1.5.0
+	github.com/sendgrid/sendgrid-go v3.14.0+incompatible
 	github.com/thanhpk/randstr v1.0.6
 	github.com/tmc/langchaingo v0.0.0-20231110174329-09a09b3b6093
 	gopkg.in/yaml.v2 v2.3.0
@@ -53,7 +54,6 @@ require (
 	github.com/pkoukk/tiktoken-go v0.1.2 // indirect
 	github.com/saintfish/chardet v0.0.0-20230101081208-5e3ef4b5456d // indirect
 	github.com/sendgrid/rest v2.6.9+incompatible // indirect
-	github.com/sendgrid/sendgrid-go v3.14.0+incompatible // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/temoto/robotstxt v1.1.2 // indirect


### PR DESCRIPTION
Since we dont need to build AdminKit anymore(import path was fixed),there is no need to do that step during local dev env setup,so I removed that step.